### PR TITLE
Use https in blockdozer URLs. Fixes signing issues.

### DIFF
--- a/js/coin.js
+++ b/js/coin.js
@@ -1067,7 +1067,7 @@
 					type: "GET",
 					cache: false,
 					async: false,
-					url: "http://blockdozer.com/insight-api/addr/"+utxo_address+"/utxo",
+					url: "https://blockdozer.com/insight-api/addr/"+utxo_address+"/utxo",
 					dataType: "json",
 					error: function(data) {
 						alert('Couldn\'t get values for inputs. Bitcoin Cash will not sign correctly.');

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -959,7 +959,7 @@ $(document).ready(function() {
 		$.ajax ({
 			type: "GET",
 			cache: false,
-			url: "http://blockdozer.com/insight-api/addr/"+redeem.addr+"/utxo",
+			url: "https://blockdozer.com/insight-api/addr/"+redeem.addr+"/utxo",
 			dataType: "json",
 			error: function(data) {
 				$("#redeemFromStatus").removeClass('hidden').html('<span class="glyphicon glyphicon-exclamation-sign"></span> Unexpected error, unable to retrieve unspent outputs!');
@@ -971,7 +971,7 @@ $(document).ready(function() {
 					data = $.parseJSON(json);
 				}
 				if((data[0].address && data[0].txid) && data[0].address==redeem.addr){
-					$("#redeemFromAddress").removeClass('hidden').html('<span class="glyphicon glyphicon-info-sign"></span> Retrieved unspent inputs from address <a href="http://blockdozer.com/insight/address/'+redeem.addr+'" target="_blank">'+redeem.addr+'</a>');
+					$("#redeemFromAddress").removeClass('hidden').html('<span class="glyphicon glyphicon-info-sign"></span> Retrieved unspent inputs from address <a href="https://blockdozer.com/insight/address/'+redeem.addr+'" target="_blank">'+redeem.addr+'</a>');
 					for(var i in data){
 						var o = data[i];
 						var tx = ((""+o.txid).match(/.{1,2}/g).reverse()).join("")+'';
@@ -1146,7 +1146,7 @@ $(document).ready(function() {
 		$(thisbtn).val('Please wait, loading...').attr('disabled',true);
 		$.ajax ({
 			type: "POST",
-			url: "http://blockdozer.com/insight-api/tx/send",
+			url: "https://blockdozer.com/insight-api/tx/send",
 			data: {"rawtx":$("#rawTransaction").val()},
 			dataType: "json",
 			error: function(data) {


### PR DESCRIPTION
It wasn't possible to sign a BCC transaction (from Chrome) when using the http URL. It worked when I replaced it with https.